### PR TITLE
Add dark mode with theme toggle

### DIFF
--- a/app/_components/sidebar.tsx
+++ b/app/_components/sidebar.tsx
@@ -1,34 +1,36 @@
 import { LayoutGridIcon, PackageIcon, ShoppingBasketIcon } from "lucide-react";
 import SidebarButton from "./ui/sidebar-button";
+import ThemeToggle from "./theme-toggle";
 const Sidebar = () => {
   return (
-    <>
-      <div className="w-64 bg-white shadow-sm">
-        {/* Imagem */}
-        <div className="px-2 py-6">
-          <h1 className="text-2xl font-extrabold">STOCKLY</h1>
-        </div>
-        {/* Botões */}
-        <div className="flex flex-col gap-2 p-2">
-          <SidebarButton
-            href="/"
-            icon={<LayoutGridIcon size={20} />}
-            text="Dashboard"
-          />
-          <SidebarButton
-            href="/products"
-            icon={<PackageIcon size={20} />}
-            text="Produtos"
-          />
-          <SidebarButton
-            href="/sales"
-            icon={<ShoppingBasketIcon size={20} />}
-            text="Vendas"
-          />
-        </div>
+    <div className="w-64 bg-white shadow-sm flex h-full flex-col">
+      {/* Imagem */}
+      <div className="px-2 py-6">
+        <h1 className="text-2xl font-extrabold">STOCKLY</h1>
       </div>
-    </>
-  );
+      {/* Botões */}
+      <div className="flex flex-1 flex-col gap-2 p-2">
+        <SidebarButton
+          href="/"
+          icon={<LayoutGridIcon size={20} />}
+          text="Dashboard"
+        />
+        <SidebarButton
+          href="/products"
+          icon={<PackageIcon size={20} />}
+          text="Produtos"
+        />
+        <SidebarButton
+          href="/sales"
+          icon={<ShoppingBasketIcon size={20} />}
+          text="Vendas"
+        />
+      </div>
+      <div className="p-2">
+        <ThemeToggle />
+      </div>
+    </div>
+  )
 };
 
 export default Sidebar;

--- a/app/_components/theme-toggle.tsx
+++ b/app/_components/theme-toggle.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import { Moon, Sun } from "lucide-react"
+import { useTheme } from "next-themes"
+import { useEffect, useState } from "react"
+
+import { Button } from "./ui/button"
+
+export default function ThemeToggle() {
+  const { setTheme, resolvedTheme } = useTheme()
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => setMounted(true), [])
+
+  if (!mounted) return null
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}
+    >
+      <Sun className="size-5 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+      <Moon className="absolute size-5 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+      <span className="sr-only">Toggle theme</span>
+    </Button>
+  )
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import Sidebar from "./_components/sidebar";
 import { Toaster } from "./_components/ui/sonner";
+import { ThemeProvider } from "./theme-provider";
 import "./globals.css";
 
 const inter = Inter({ subsets: ["latin"], display: "auto" });
@@ -15,19 +16,21 @@ export const metadata: Metadata = {
 export default function RootLayout({
   children,
 }: Readonly<{
-  children: React.ReactNode;
+  children: React.ReactNode
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body className={`${inter.className} antialiased`}>
-        <div className="flex h-full">
-          <div className="flex h-full  bg-white shadow-lg transition-transform">
-            <Sidebar />
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+          <div className="flex h-full">
+            <div className="flex h-full bg-white shadow-lg transition-transform">
+              <Sidebar />
+            </div>
+            {children}
           </div>
-          {children}
-        </div>
-        <Toaster />
+          <Toaster />
+        </ThemeProvider>
       </body>
     </html>
-  );
+  )
 }

--- a/app/theme-provider.tsx
+++ b/app/theme-provider.tsx
@@ -1,0 +1,8 @@
+"use client"
+
+import { ThemeProvider as NextThemesProvider } from "next-themes"
+import type { ThemeProviderProps } from "next-themes/dist/types"
+
+export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>
+}


### PR DESCRIPTION
## Summary
- add theme provider using `next-themes`
- implement a theme toggle button
- include theme provider in layout
- add theme toggle to sidebar

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841837a8f40832f9d0f6a2bed347e37